### PR TITLE
Fix ValueError in FireRedTTS3Instruct.generate_tts

### DIFF
--- a/fireredtts3/core.py
+++ b/fireredtts3/core.py
@@ -381,7 +381,7 @@ class FireRedTTS3Instruct(TextFrontendMixin, FireRedTTS3InstructBackend):
         gen_audio_sr = None
         segments: List[torch.Tensor] = []
         for sent in sentences:
-            seg, seg_sr, _ = super().generate_tts(
+            seg, seg_sr = super().generate_tts(
                 prompt_text=prompt_text,
                 prompt_audio=prompt_audio,
                 prompt_audio_sr=prompt_audio_sr,


### PR DESCRIPTION
### Problem

Every call to `fireredtts3.core.FireRedTTS3Instruct.generate_tts` fails, on any device:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

The text-frontend wrapper unpacks three values:

https://github.com/FireRedTeam/FireRedTTS3/blob/main/fireredtts3/core.py#L384

but the backend `FireRedTTS3Instruct.generate_tts` in `fireredtts3/llm/fireredtts3_instruct.py` returns only `(gen_audio, gen_audio_sr)` — which is also the two-value form documented in the README:

```python
gen_audio, gen_audio_sr = instruct.generate_tts(...)
```

The sibling methods differ genuinely: `generate_voice_design` and `generate_semantic_edit` do return a third `gen_text` (the CoT plan / rewritten text), so only this one call site is wrong.

### Repro

```python
from fireredtts3.core import FireRedTTS3Instruct
instruct = FireRedTTS3Instruct("pretrained_models")
instruct.generate_tts(prompt_text=..., prompt_audio=..., prompt_audio_sr=..., text=...)
```

### Fix

Unpack two values. One-line change, no behaviour change elsewhere.

### Testing

ICL zero-shot cloning through `FireRedTTS3Instruct.generate_tts` now completes and produces correct audio; verified together with `generate_voice_design`, `generate_semantic_edit` and `generate_acoustic_edit`, which were already fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
